### PR TITLE
Added support to create certificates in PEM format

### DIFF
--- a/src/main/kotlin/ch/hevs/cloudio/cloud/internalservice/certificatemanager/CertificateManagerProxy.kt
+++ b/src/main/kotlin/ch/hevs/cloudio/cloud/internalservice/certificatemanager/CertificateManagerProxy.kt
@@ -53,4 +53,11 @@ class CertificateManagerProxy(private val rabbitTemplate: RabbitTemplate) {
         }
         return response.pkcs12Data
     }
+
+    fun generateEndpointKeyAndCertificateAsPEM(endpointUUID: UUID): String {
+        return rabbitTemplate.convertSendAndReceive("cloudio.service.internal",
+                "CertificateManagerService::generateEndpointKeyAndCertificateAsPEM",
+                endpointUUID.toString())
+                as String
+    }
 }


### PR DESCRIPTION
OpenSSL is not able to export the keys inside the PKCS12 file created by the certificate creation REST API, by providing an API where the certificates can be retrieved as PEM we do not have the problem anymore.