### PR TITLE
Improved build info & info REST API

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,8 +8,21 @@ plugins {
     id("com.google.cloud.tools.jib") version "2.5.0"
 }
 
+open class GitTools(p: String) {
+    val tag: String? by lazy {
+        Runtime.getRuntime().exec("git describe --exact-match --tags HEAD").let {
+            it.waitFor()
+            if (it.exitValue() == 0) String(it.inputStream.readAllBytes()).trim() else null
+        }
+    }
+    val hash: String by lazy { String(Runtime.getRuntime().exec("git rev-parse HEAD").inputStream.readAllBytes()).trim() }
+    val shortHash: String by lazy { String(Runtime.getRuntime().exec("git rev-parse --short HEAD").inputStream.readAllBytes()).trim() }
+}
+val git: GitTools by project
+project.extensions.create("git", GitTools::class.java, "")
+
 group = "ch.hevs.cloudio"
-version = "0.2.0-SNAPSHOT"
+version = git.tag ?: "SNAPSHOT-${git.shortHash}"
 java.sourceCompatibility = JavaVersion.VERSION_11
 
 springBoot {

--- a/src/main/kotlin/ch/hevs/cloudio/cloud/main.kt
+++ b/src/main/kotlin/ch/hevs/cloudio/cloud/main.kt
@@ -128,7 +128,8 @@ class CloudioApplication {
                     .authorizeRequests().antMatchers(
                             "/v2/api-docs",
                             "/api/v1/provision/*",
-                            "/messageformat/**"
+                            "/messageformat/**",
+                            "/api/v1/info/*"
                     ).permitAll()
                     .anyRequest().hasAuthority(Authority.HTTP_ACCESS.name)
                     .and().httpBasic()

--- a/src/main/kotlin/ch/hevs/cloudio/cloud/restapi/node/PublicNodeInfoController.kt
+++ b/src/main/kotlin/ch/hevs/cloudio/cloud/restapi/node/PublicNodeInfoController.kt
@@ -1,0 +1,65 @@
+package ch.hevs.cloudio.cloud.restapi.node
+
+import ch.hevs.cloudio.cloud.security.Authority
+import io.swagger.annotations.Api
+import io.swagger.annotations.ApiOperation
+import org.springframework.boot.info.BuildProperties
+import org.springframework.context.annotation.Profile
+import org.springframework.http.HttpStatus
+import org.springframework.security.core.Authentication
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import springfox.documentation.annotations.ApiIgnore
+import java.lang.management.ManagementFactory
+import java.net.InetAddress
+
+@Profile("rest-api")
+@Api(
+    tags = ["Node info"],
+    description = "Information about the cloud.iO service node."
+)
+@RestController
+@RequestMapping("api/v1/info")
+class PublicNodeInfoController(
+    private val buildProperties: BuildProperties
+) {
+    @GetMapping("/node")
+    @ResponseStatus(HttpStatus.OK)
+    @ApiOperation("Returns node info.")
+    fun getNodeInfo(@ApiIgnore authentication: Authentication?) = mutableMapOf(
+        "version" to buildProperties.version,
+        "build date" to buildProperties.time
+    ).apply {
+        if (authentication?.authorities?.contains(SimpleGrantedAuthority(Authority.HTTP_ADMIN.toString())) == true) {
+            set("host", InetAddress.getLocalHost().hostName)
+            set("address", InetAddress.getLocalHost().hostAddress)
+            ManagementFactory.getRuntimeMXBean().also {
+                set("jvm", "${it.vmName} ${it.vmVersion}")
+                set("uptime", it.uptime)
+                set("pid", it.pid)
+            }
+            ManagementFactory.getMemoryMXBean().also {
+                set("memory", mapOf(
+                    "heap" to mapOf(
+                        "init" to it.heapMemoryUsage.init,
+                        "used" to it.heapMemoryUsage.used,
+                        "comitted" to it.heapMemoryUsage.committed,
+                        "max" to it.heapMemoryUsage.max
+                    ),
+                    "other" to mapOf(
+                        "init" to it.nonHeapMemoryUsage.init,
+                        "used" to it.nonHeapMemoryUsage.used,
+                        "comitted" to it.nonHeapMemoryUsage.committed
+                    )
+                ))
+            }
+            ManagementFactory.getThreadMXBean().also {
+                set("threads", it.threadCount)
+                set("peak-threads", it.peakThreadCount)
+            }
+        }
+    }
+}


### PR DESCRIPTION
It is hard to determine which version (of a snapshot) is actually running. This modification sets the version info of all intermediate snapshots as "SNAPSHOT-{GIT hash} or to the respective tag if the repo is at a tag.