### PR TITLE
Feature/influx2 compatibility api

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -84,8 +84,10 @@ tasks.bootRun {
     doFirst {
         tasks.bootRun.configure {
             val adminPassword: String? by project
+            val influxToken: String? by project
 
             environment("cloudio.initialAdminPassword", adminPassword ?: "admin_password")
+            environment("cloudio.influx.token", influxToken?:"influx_token")
 
             // Certificate manager.
             environment("cloudio.cert-manager.caCertificate", file("cloudio-dev-environment/certificates/ca.cer").readText())
@@ -115,6 +117,7 @@ tasks.test {
     doFirst {
         tasks.test.configure {
             val adminPassword: String? by project
+            val influxToken: String? by project
 
             // Certificate manager.
             environment("cloudio.cert-manager.caCertificate", file("cloudio-dev-environment/certificates/ca.cer").readText())
@@ -127,6 +130,7 @@ tasks.test {
             // InfluxDB.
             environment("spring.influx.url", "http://localhost:8086")
             environment("cloudio.influx.database", "cloudio-bucket")
+            environment("cloudio.influx.token", influxToken?:"influx_token")
 
             // MongoDB.
             environment("spring.data.mongodb.host", "localhost")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -85,7 +85,7 @@ tasks.bootRun {
         tasks.bootRun.configure {
             val adminPassword: String? by project
 
-            environment("cloudio.initialAdminPassword", adminPassword ?: "admin")
+            environment("cloudio.initialAdminPassword", adminPassword ?: "admin_password")
 
             // Certificate manager.
             environment("cloudio.cert-manager.caCertificate", file("cloudio-dev-environment/certificates/ca.cer").readText())
@@ -104,7 +104,7 @@ tasks.bootRun {
             // PostgreSQL.
             environment("spring.datasource.url", "jdbc:postgresql://localhost:5432/cloudio")
             environment("spring.datasource.username", "cloudio")
-            environment("spring.datasource.password", adminPassword ?: "admin")
+            environment("spring.datasource.password", adminPassword ?: "admin_password")
             environment("jpa.hibernate.ddl-auto" ,"update")
         }
     }
@@ -126,7 +126,7 @@ tasks.test {
 
             // InfluxDB.
             environment("spring.influx.url", "http://localhost:8086")
-            environment("cloudio.influx.database", "cloudiotest")
+            environment("cloudio.influx.database", "cloudio-bucket")
 
             // MongoDB.
             environment("spring.data.mongodb.host", "localhost")
@@ -135,7 +135,7 @@ tasks.test {
             // PostgreSQL.
             environment("spring.datasource.url", "jdbc:postgresql://localhost:5432/cloudiotest")
             environment("spring.datasource.username", "cloudio")
-            environment("spring.datasource.password", adminPassword ?: "admin")
+            environment("spring.datasource.password", adminPassword ?: "admin_password")
             environment("jpa.hibernate.ddl-auto" ,"create")
 
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,7 +60,7 @@ dependencies {
 
     implementation("org.postgresql:postgresql")
     implementation("com.vladmihalcea:hibernate-types-52:2.18.0")
-    implementation("org.influxdb:influxdb-java")
+    implementation("com.influxdb:influxdb-client-java:6.7.0")
     implementation("org.bouncycastle:bcpkix-jdk15on:1.70")
 
     testImplementation("org.jetbrains.kotlin:kotlin-test:1.6.21")

--- a/cloudio-dev-environment/build.gradle.kts
+++ b/cloudio-dev-environment/build.gradle.kts
@@ -16,7 +16,9 @@ tasks.register<Exec>("createDevServices") {
     workingDir = file(".")
     doFirst {
         val adminPassword: String? by project
+        val influxToken: String? by project
         environment["ADMIN_PASSWORD"] = adminPassword ?: "admin_password"
+        environment["INFLUX_TOKEN"] =  influxToken?:"influx_token"
         environment["CA_CERT"] = file("certificates/ca.cer").readText()
         environment["SERVER_CERT"] = file("certificates/server.cer").readText()
         environment["SERVER_KEY"] = file("certificates/server.key").readText()

--- a/cloudio-dev-environment/build.gradle.kts
+++ b/cloudio-dev-environment/build.gradle.kts
@@ -16,7 +16,7 @@ tasks.register<Exec>("createDevServices") {
     workingDir = file(".")
     doFirst {
         val adminPassword: String? by project
-        environment["ADMIN_PASSWORD"] = adminPassword ?: "admin"
+        environment["ADMIN_PASSWORD"] = adminPassword ?: "admin_password"
         environment["CA_CERT"] = file("certificates/ca.cer").readText()
         environment["SERVER_CERT"] = file("certificates/server.cer").readText()
         environment["SERVER_KEY"] = file("certificates/server.key").readText()

--- a/cloudio-dev-environment/docker-compose.yml
+++ b/cloudio-dev-environment/docker-compose.yml
@@ -16,6 +16,13 @@ services:
     image: influxdb:2.6.1
     ports:
     - "8086:8086"
+    environment:
+      DOCKER_INFLUXDB_INIT_MODE: setup
+      DOCKER_INFLUXDB_INIT_USERNAME: admin
+      DOCKER_INFLUXDB_INIT_PASSWORD: ${ADMIN_PASSWORD}
+      DOCKER_INFLUXDB_INIT_ORG: cloudio-org
+      DOCKER_INFLUXDB_INIT_BUCKET: cloudio-bucket
+      DOCKER_INFLUXDB_INIT_ADMIN_TOKEN: ${INFLUX_TOKEN}
 
   database:
     image: postgres:14.5-alpine

--- a/cloudio-dev-environment/docker-compose.yml
+++ b/cloudio-dev-environment/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   rabbitmq:
-    image: cloudio/cloudio-rabbitmq:3.11.10
+    image: cloudio/cloudio-rabbitmq:3.11.10-1
     ports:
     - "8883:8883"
     - "5671:5671"

--- a/cloudio-dev-environment/docker-compose.yml
+++ b/cloudio-dev-environment/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   rabbitmq:
-    image: cloudio/cloudio-rabbitmq:3.9.22-1
+    image: cloudio/cloudio-rabbitmq:3.11.10
     ports:
     - "8883:8883"
     - "5671:5671"

--- a/cloudio-dev-environment/docker-compose.yml
+++ b/cloudio-dev-environment/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       SERVER_KEY: ${SERVER_KEY}
 
   influx:
-    image: influxdb:1.8.10
+    image: influxdb:2.6.1
     ports:
     - "8086:8086"
 

--- a/src/main/kotlin/ch/hevs/cloudio/cloud/config/CloudioInfluxProperties.kt
+++ b/src/main/kotlin/ch/hevs/cloudio/cloud/config/CloudioInfluxProperties.kt
@@ -8,6 +8,8 @@ import org.springframework.boot.context.properties.ConstructorBinding
 data class CloudioInfluxProperties(
         val database: String = "cloudio-bucket",
         val organization: String = "cloudio-org",
+        val token: String = "",
+        val url: String = "http://localhost:8086",
         val batchIntervalMs: Int = 3000,
         val batchSize: Int = 2000
 )

--- a/src/main/kotlin/ch/hevs/cloudio/cloud/config/CloudioInfluxProperties.kt
+++ b/src/main/kotlin/ch/hevs/cloudio/cloud/config/CloudioInfluxProperties.kt
@@ -6,7 +6,8 @@ import org.springframework.boot.context.properties.ConstructorBinding
 @ConstructorBinding
 @ConfigurationProperties(prefix = "cloudio.influx")
 data class CloudioInfluxProperties(
-        val database: String = "cloudio",
+        val database: String = "cloudio-bucket",
+        val organization: String = "cloudio-org",
         val batchIntervalMs: Int = 3000,
         val batchSize: Int = 2000
 )

--- a/src/main/kotlin/ch/hevs/cloudio/cloud/dao/UserEndpointPermission.kt
+++ b/src/main/kotlin/ch/hevs/cloudio/cloud/dao/UserEndpointPermission.kt
@@ -1,8 +1,8 @@
 package ch.hevs.cloudio.cloud.dao
 
+import ch.hevs.cloudio.cloud.security.AbstractEndpointPermission
 import ch.hevs.cloudio.cloud.security.EndpointModelElementPermission
 import ch.hevs.cloudio.cloud.security.EndpointPermission
-import ch.hevs.cloudio.cloud.security.AbstractEndpointPermission
 import java.util.*
 import javax.persistence.*
 

--- a/src/main/kotlin/ch/hevs/cloudio/cloud/dao/UserGroupEndpointPermission.kt
+++ b/src/main/kotlin/ch/hevs/cloudio/cloud/dao/UserGroupEndpointPermission.kt
@@ -1,8 +1,8 @@
 package ch.hevs.cloudio.cloud.dao
 
+import ch.hevs.cloudio.cloud.security.AbstractEndpointPermission
 import ch.hevs.cloudio.cloud.security.EndpointModelElementPermission
 import ch.hevs.cloudio.cloud.security.EndpointPermission
-import ch.hevs.cloudio.cloud.security.AbstractEndpointPermission
 import java.util.*
 import javax.persistence.*
 

--- a/src/main/kotlin/ch/hevs/cloudio/cloud/extension/model.kt
+++ b/src/main/kotlin/ch/hevs/cloudio/cloud/extension/model.kt
@@ -4,8 +4,9 @@ import ch.hevs.cloudio.cloud.model.Attribute
 import ch.hevs.cloudio.cloud.model.CloudioObject
 import ch.hevs.cloudio.cloud.model.EndpointDataModel
 import ch.hevs.cloudio.cloud.model.Node
-import org.influxdb.InfluxDB
-import org.influxdb.dto.Query
+import com.influxdb.client.InfluxDBClient
+import com.influxdb.client.InfluxQLQueryApi
+import com.influxdb.client.domain.InfluxQLQuery
 import java.text.ParseException
 import java.text.SimpleDateFormat
 import java.util.*
@@ -40,19 +41,19 @@ fun CloudioObject.findObject(path: Stack<String>): CloudioObject? = when {
     else -> null
 }
 
-fun EndpointDataModel.fillAttributesFromInfluxDB(influx: InfluxDB, database: String, endpointUuid: UUID) {
+fun EndpointDataModel.fillAttributesFromInfluxDB(influx: InfluxDBClient, database: String, endpointUuid: UUID) {
     this.nodes.forEach {
         it.value.fillAttributesFromInfluxDB(influx, database, "${endpointUuid}/${it.key}")
     }
 }
 
-fun Node.fillAttributesFromInfluxDB(influx: InfluxDB, database: String, topic: String) {
+fun Node.fillAttributesFromInfluxDB(influx: InfluxDBClient, database: String, topic: String) {
     this.objects.forEach {
         it.value.fillAttributesFromInfluxDB(influx, database, "$topic/${it.key}")
     }
 }
 
-fun CloudioObject.fillAttributesFromInfluxDB(influx: InfluxDB, database: String, topic: String) {
+fun CloudioObject.fillAttributesFromInfluxDB(influx: InfluxDBClient, database: String, topic: String) {
     this.attributes.forEach {
         it.value.fillFromInfluxDB(influx, database, "$topic/${it.key}")
     }
@@ -61,7 +62,28 @@ fun CloudioObject.fillAttributesFromInfluxDB(influx: InfluxDB, database: String,
     }
 }
 
-fun Attribute.fillFromInfluxDB(influx: InfluxDB, database: String, topic: String) {
+fun Attribute.fillFromInfluxDB(influx: InfluxDBClient, database: String, topic: String) {
+    //TODO update to influx 2.x
+    var queryApi: InfluxQLQueryApi  = influx.influxQLQueryApi
+
+    queryApi.query(InfluxQLQuery("SELECT value from \"${topic.replace('/', '.')}\" ORDER BY desc LIMIT 1", database)).results[0].series.let {
+        var dt: Date? = null
+        try {
+            dt = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'").parse(it[0].values[0].toString())
+        } catch (exception: ParseException) {
+            try {
+                dt = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").parse(it[0].values[0].toString())
+            } catch (exception: ParseException) {
+                exception.printStackTrace()
+            }
+        }
+        if (dt != null) {
+            this.value = it[0].values[1]
+            this.timestamp = dt.time.toDouble()
+        }
+    }
+
+    /*
     influx.query(Query("SELECT value from \"${topic.replace('/', '.')}\" ORDER BY desc LIMIT 1", database)).results[0].series?.let {
         var dt: Date? = null
         try {
@@ -78,4 +100,5 @@ fun Attribute.fillFromInfluxDB(influx: InfluxDB, database: String, topic: String
             this.timestamp = dt.time.toDouble()
         }
     }
+    */
 }

--- a/src/main/kotlin/ch/hevs/cloudio/cloud/extension/model.kt
+++ b/src/main/kotlin/ch/hevs/cloudio/cloud/extension/model.kt
@@ -69,16 +69,16 @@ fun Attribute.fillFromInfluxDB(influx: InfluxDBClient, database: String, topic: 
     queryApi.query(InfluxQLQuery("SELECT value from \"${topic.replace('/', '.')}\" ORDER BY desc LIMIT 1", database)).results[0].series.let {
         var dt: Date? = null
         try {
-            dt = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'").parse(it[0].values[0].toString())
+            dt = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'").parse(it[0].values[0].values[0].toString())
         } catch (exception: ParseException) {
             try {
-                dt = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").parse(it[0].values[0].toString())
+                dt = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").parse(it[0].values[0].values[0].toString())
             } catch (exception: ParseException) {
                 exception.printStackTrace()
             }
         }
         if (dt != null) {
-            this.value = it[0].values[1]
+            this.value = it[0].values[0].values[1]
             this.timestamp = dt.time.toDouble()
         }
     }

--- a/src/main/kotlin/ch/hevs/cloudio/cloud/extension/model.kt
+++ b/src/main/kotlin/ch/hevs/cloudio/cloud/extension/model.kt
@@ -9,7 +9,6 @@ import com.influxdb.client.InfluxQLQueryApi
 import com.influxdb.client.domain.InfluxQLQuery
 import com.influxdb.query.InfluxQLQueryResult
 import java.text.ParseException
-import java.text.SimpleDateFormat
 import java.util.*
 
 fun EndpointDataModel.findAttribute(path: Stack<String>): Attribute? = if (path.size > 1) {
@@ -64,7 +63,6 @@ fun CloudioObject.fillAttributesFromInfluxDB(influx: InfluxDBClient, database: S
 }
 
 fun Attribute.fillFromInfluxDB(influx: InfluxDBClient, database: String, topic: String) {
-    //TODO update to influx 2.x
     val queryApi: InfluxQLQueryApi = influx.influxQLQueryApi
 
     val myQuery: InfluxQLQueryResult? = queryApi.query(
@@ -91,23 +89,4 @@ fun Attribute.fillFromInfluxDB(influx: InfluxDBClient, database: String, topic: 
             }
         }
     }
-
-    /*
-    influx.query(Query("SELECT value from \"${topic.replace('/', '.')}\" ORDER BY desc LIMIT 1", database)).results[0].series?.let {
-        var dt: Date? = null
-        try {
-            dt = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'").parse(it[0].values[0][0].toString())
-        } catch (exception: ParseException) {
-            try {
-                dt = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").parse(it[0].values[0][0].toString())
-            } catch (exception: ParseException) {
-                exception.printStackTrace()
-            }
-        }
-        if (dt != null) {
-            this.value = it[0].values[0][1]
-            this.timestamp = dt.time.toDouble()
-        }
-    }
-    */
 }

--- a/src/main/kotlin/ch/hevs/cloudio/cloud/extension/security.kt
+++ b/src/main/kotlin/ch/hevs/cloudio/cloud/extension/security.kt
@@ -14,7 +14,6 @@ import org.springframework.security.core.Authentication
 import java.io.OutputStream
 import java.io.StringReader
 import java.io.StringWriter
-import java.lang.RuntimeException
 import java.math.BigInteger
 import java.security.KeyStore
 import java.security.PrivateKey

--- a/src/main/kotlin/ch/hevs/cloudio/cloud/main.kt
+++ b/src/main/kotlin/ch/hevs/cloudio/cloud/main.kt
@@ -8,6 +8,9 @@ import ch.hevs.cloudio.cloud.security.CloudioUserDetails
 import ch.hevs.cloudio.cloud.security.CloudioUserDetailsService
 import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.influxdb.client.InfluxDBClient
+import com.influxdb.client.InfluxDBClientFactory
+import com.influxdb.client.InfluxDBClientOptions
 import com.rabbitmq.client.DefaultSaslConfig
 import io.swagger.v3.oas.annotations.OpenAPIDefinition
 import io.swagger.v3.oas.annotations.enums.SecuritySchemeType
@@ -188,6 +191,11 @@ class CloudioApplication {
         } else {
             Optional.empty()
         }
+    }
+
+    @Bean
+    fun influxDBClient(): InfluxDBClient? {
+        return InfluxDBClientFactory.create("http://localhost:8086", "token", "cloudio-org", "cloudio-bucket");
     }
 }
 

--- a/src/main/kotlin/ch/hevs/cloudio/cloud/restapi/admin/usergroup/UserGroupEntity.kt
+++ b/src/main/kotlin/ch/hevs/cloudio/cloud/restapi/admin/usergroup/UserGroupEntity.kt
@@ -1,6 +1,5 @@
 package ch.hevs.cloudio.cloud.restapi.admin.usergroup
 
-import ch.hevs.cloudio.cloud.dao.UserGroup
 import ch.hevs.cloudio.cloud.restapi.admin.user.ListUserEntity
 import io.swagger.v3.oas.annotations.media.Schema
 

--- a/src/main/kotlin/ch/hevs/cloudio/cloud/restapi/endpoint/data/EndpointDataAccessController.kt
+++ b/src/main/kotlin/ch/hevs/cloudio/cloud/restapi/endpoint/data/EndpointDataAccessController.kt
@@ -12,6 +12,7 @@ import ch.hevs.cloudio.cloud.security.EndpointModelElementPermission
 import ch.hevs.cloudio.cloud.security.EndpointPermission
 import ch.hevs.cloudio.cloud.serialization.SerializationFormat
 import ch.hevs.cloudio.cloud.serialization.fromIdentifiers
+import com.influxdb.client.InfluxDBClient
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.Content
@@ -20,7 +21,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
-import com.influxdb.client.InfluxDBClient
 import org.springframework.amqp.rabbit.core.RabbitTemplate
 import org.springframework.context.annotation.Profile
 import org.springframework.http.HttpStatus
@@ -38,7 +38,7 @@ import javax.servlet.http.HttpServletRequest
 class EndpointDataAccessController(
     private val endpointRepository: EndpointRepository,
     private val permissionManager: CloudioPermissionManager,
-    private val influxDB: InfluxDBClient,//TODO update to influx 2.x
+    private val influxDB: InfluxDBClient,
     private val influxProperties: CloudioInfluxProperties,
     private val serializationFormats: Collection<SerializationFormat>,
     private val rabbitTemplate: RabbitTemplate

--- a/src/main/kotlin/ch/hevs/cloudio/cloud/restapi/endpoint/data/EndpointDataAccessController.kt
+++ b/src/main/kotlin/ch/hevs/cloudio/cloud/restapi/endpoint/data/EndpointDataAccessController.kt
@@ -20,7 +20,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
-import org.influxdb.InfluxDB
+import com.influxdb.client.InfluxDBClient
 import org.springframework.amqp.rabbit.core.RabbitTemplate
 import org.springframework.context.annotation.Profile
 import org.springframework.http.HttpStatus
@@ -38,7 +38,7 @@ import javax.servlet.http.HttpServletRequest
 class EndpointDataAccessController(
     private val endpointRepository: EndpointRepository,
     private val permissionManager: CloudioPermissionManager,
-    private val influxDB: InfluxDB,
+    private val influxDB: InfluxDBClient,//TODO update to influx 2.x
     private val influxProperties: CloudioInfluxProperties,
     private val serializationFormats: Collection<SerializationFormat>,
     private val rabbitTemplate: RabbitTemplate

--- a/src/main/kotlin/ch/hevs/cloudio/cloud/restapi/endpoint/data/EndpointWOTAccessController.kt
+++ b/src/main/kotlin/ch/hevs/cloudio/cloud/restapi/endpoint/data/EndpointWOTAccessController.kt
@@ -11,6 +11,7 @@ import ch.hevs.cloudio.cloud.restapi.CloudioHttpExceptions
 import ch.hevs.cloudio.cloud.security.CloudioPermissionManager
 import ch.hevs.cloudio.cloud.security.EndpointPermission
 import ch.hevs.cloudio.cloud.serialization.wot.WotSerializationFormat
+import com.influxdb.client.InfluxDBClient
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.Content
@@ -19,7 +20,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
-import com.influxdb.client.InfluxDBClient
 import org.springframework.context.annotation.Profile
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
@@ -37,7 +37,7 @@ import javax.servlet.http.HttpServletRequest
 @SecurityRequirement(name = "basicAuth")
 class EndpointWOTAccessController(private val endpointRepository: EndpointRepository,
                                   private val permissionManager: CloudioPermissionManager,
-                                  private val influxDB: InfluxDBClient,//TODO update to influx 2.x
+                                  private val influxDB: InfluxDBClient,
                                   private val influxProperties: CloudioInfluxProperties) {
     private val antMatcher = AntPathMatcher()
 

--- a/src/main/kotlin/ch/hevs/cloudio/cloud/restapi/endpoint/data/EndpointWOTAccessController.kt
+++ b/src/main/kotlin/ch/hevs/cloudio/cloud/restapi/endpoint/data/EndpointWOTAccessController.kt
@@ -19,7 +19,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
-import org.influxdb.InfluxDB
+import com.influxdb.client.InfluxDBClient
 import org.springframework.context.annotation.Profile
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
@@ -37,7 +37,7 @@ import javax.servlet.http.HttpServletRequest
 @SecurityRequirement(name = "basicAuth")
 class EndpointWOTAccessController(private val endpointRepository: EndpointRepository,
                                   private val permissionManager: CloudioPermissionManager,
-                                  private val influxDB: InfluxDB,
+                                  private val influxDB: InfluxDBClient,//TODO update to influx 2.x
                                   private val influxProperties: CloudioInfluxProperties) {
     private val antMatcher = AntPathMatcher()
 

--- a/src/main/kotlin/ch/hevs/cloudio/cloud/restapi/endpoint/group/EndpointGroupListEntity.kt
+++ b/src/main/kotlin/ch/hevs/cloudio/cloud/restapi/endpoint/group/EndpointGroupListEntity.kt
@@ -2,7 +2,6 @@ package ch.hevs.cloudio.cloud.restapi.endpoint.group
 
 import ch.hevs.cloudio.cloud.security.EndpointPermission
 import io.swagger.v3.oas.annotations.media.Schema
-import java.util.*
 
 @Schema(name = "EndpointGroupListEntry", description = "Endpoint group overview used in endpoint group listing.")
 data class EndpointGroupListEntity(

--- a/src/main/kotlin/ch/hevs/cloudio/cloud/restapi/endpoint/history/EndpointHistoryAccessController.kt
+++ b/src/main/kotlin/ch/hevs/cloudio/cloud/restapi/endpoint/history/EndpointHistoryAccessController.kt
@@ -193,12 +193,6 @@ class EndpointHistoryAccessController(
                     "LIMIT ${max ?: 1000}",
             influxProperties.database))
 
-        /* //TODO update to influx 2.x.hasError() doesn't exist anymore
-        if (result.hasError()) {
-            throw CloudioHttpExceptions.InternalServerError("InfluxDB error: ${result.error}")
-        }
-        */
-
         return result.results.firstOrNull()?.series?.firstOrNull()
     }
 

--- a/src/main/kotlin/ch/hevs/cloudio/cloud/restapi/endpoint/log/EndpointLogController.kt
+++ b/src/main/kotlin/ch/hevs/cloudio/cloud/restapi/endpoint/log/EndpointLogController.kt
@@ -83,7 +83,7 @@ class EndpointLogController(
         return result.results.firstOrNull()?.series?.firstOrNull()?.values?.map {
             LogMessageEntity(
                 time = it.values[0] as String,
-                level = LogLevel.values()[(it.values[1] as Double).toInt()],
+                level = LogLevel.values()[Integer.parseInt(it.values[1] as String)],
                 message = it.values[2] as String,
                 loggerName = it.values[3] as String,
                 logSource = it.values[4] as String

--- a/src/main/kotlin/ch/hevs/cloudio/cloud/restapi/endpoint/log/EndpointLogController.kt
+++ b/src/main/kotlin/ch/hevs/cloudio/cloud/restapi/endpoint/log/EndpointLogController.kt
@@ -12,8 +12,9 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
-import org.influxdb.InfluxDB
-import org.influxdb.dto.Query
+import com.influxdb.client.InfluxDBClient
+import com.influxdb.client.InfluxQLQueryApi
+import com.influxdb.client.domain.InfluxQLQuery
 import org.springframework.context.annotation.Profile
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
@@ -28,7 +29,7 @@ import java.util.*
 @RequestMapping("/api/v1/endpoints")
 @SecurityRequirement(name = "basicAuth")
 class EndpointLogController(
-    private val influx: InfluxDB,
+    private val influx: InfluxDBClient,
     private val influxProperties: CloudioInfluxProperties
 ) {
     @GetMapping("/{uuid}/log", produces = [MediaType.APPLICATION_JSON_VALUE])
@@ -49,6 +50,9 @@ class EndpointLogController(
         @RequestParam @Parameter(description = "Optional end date (UTC) in the format 'yyyy-MM-ddTHH:mm:ss'. Default is to no end date (all log output).", required = false) to: String?,
         @RequestParam @Parameter(description = "Maximal number of log entries to return.", required = false, schema = Schema(defaultValue = "1000")) max: Int?
     ): List<LogMessageEntity> {
+
+        //TODO update to influx 2.x
+        /*
         val result = influx.query(Query(
             "SELECT time, level, message, logSource, loggerName FROM \"$uuid.logs\" " +
                     "WHERE level <= ${(threshold ?: LogLevel.WARN).ordinal} " +
@@ -58,17 +62,31 @@ class EndpointLogController(
                     "LIMIT ${max ?: 1000}",
             influxProperties.database))
 
+         */
+        var queryApi: InfluxQLQueryApi = influx.influxQLQueryApi
+
+        val result = queryApi.query(InfluxQLQuery(
+                "SELECT time, level, message, logSource, loggerName FROM \"$uuid.logs\" " +
+                        "WHERE level <= ${(threshold ?: LogLevel.WARN).ordinal} " +
+                        (from?.let { "AND time >= '${it.toDate().toRFC3339()}' " } ?: "") +
+                        (to?.let { "AND time <= '${it.toDate().toRFC3339()}' " } ?: "") +
+                        "ORDER BY time DESC " +
+                        "LIMIT ${max ?: 1000}",
+            influxProperties.database))
+        /*//TODO update to influx 2.x.hasError() doesn't exist anymore
         if (result.hasError()) {
             throw CloudioHttpExceptions.InternalServerError("InfluxDB error: ${result.error}")
         }
+         */
 
+        //TODO update to influx 2.x changed it[0] to it.values[0]
         return result.results.firstOrNull()?.series?.firstOrNull()?.values?.map {
             LogMessageEntity(
-                time = it[0] as String,
-                level = LogLevel.values()[(it[1] as Double).toInt()],
-                message = it[2] as String,
-                loggerName = it[3] as String,
-                logSource = it[4] as String
+                time = it.values[0] as String,
+                level = LogLevel.values()[(it.values[1] as Double).toInt()],
+                message = it.values[2] as String,
+                loggerName = it.values[3] as String,
+                logSource = it.values[4] as String
             )
         } ?: emptyList()
     }

--- a/src/main/kotlin/ch/hevs/cloudio/cloud/restapi/endpoint/log/EndpointLogController.kt
+++ b/src/main/kotlin/ch/hevs/cloudio/cloud/restapi/endpoint/log/EndpointLogController.kt
@@ -61,12 +61,7 @@ class EndpointLogController(
                         "ORDER BY time DESC " +
                         "LIMIT ${max ?: 1000}",
             influxProperties.database))
-        /*//TODO update to influx 2.x.hasError() doesn't exist anymore
-        if (result.hasError()) {
-            throw CloudioHttpExceptions.InternalServerError("InfluxDB error: ${result.error}")
-        }
-         */
-
+        
         return result.results.firstOrNull()?.series?.firstOrNull()?.values?.map {
             LogMessageEntity(
                 time = it.values[0] as String,

--- a/src/main/kotlin/ch/hevs/cloudio/cloud/restapi/endpoint/log/EndpointLogController.kt
+++ b/src/main/kotlin/ch/hevs/cloudio/cloud/restapi/endpoint/log/EndpointLogController.kt
@@ -3,6 +3,9 @@ package ch.hevs.cloudio.cloud.restapi.endpoint.log
 import ch.hevs.cloudio.cloud.config.CloudioInfluxProperties
 import ch.hevs.cloudio.cloud.model.LogLevel
 import ch.hevs.cloudio.cloud.restapi.CloudioHttpExceptions
+import com.influxdb.client.InfluxDBClient
+import com.influxdb.client.InfluxQLQueryApi
+import com.influxdb.client.domain.InfluxQLQuery
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.ArraySchema
@@ -12,9 +15,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
-import com.influxdb.client.InfluxDBClient
-import com.influxdb.client.InfluxQLQueryApi
-import com.influxdb.client.domain.InfluxQLQuery
 import org.springframework.context.annotation.Profile
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
@@ -51,19 +51,7 @@ class EndpointLogController(
         @RequestParam @Parameter(description = "Maximal number of log entries to return.", required = false, schema = Schema(defaultValue = "1000")) max: Int?
     ): List<LogMessageEntity> {
 
-        //TODO update to influx 2.x
-        /*
-        val result = influx.query(Query(
-            "SELECT time, level, message, logSource, loggerName FROM \"$uuid.logs\" " +
-                    "WHERE level <= ${(threshold ?: LogLevel.WARN).ordinal} " +
-                    (from?.let { "AND time >= '${it.toDate().toRFC3339()}' " } ?: "") +
-                    (to?.let { "AND time <= '${it.toDate().toRFC3339()}' " } ?: "") +
-                    "ORDER BY time DESC " +
-                    "LIMIT ${max ?: 1000}",
-            influxProperties.database))
-
-         */
-        var queryApi: InfluxQLQueryApi = influx.influxQLQueryApi
+        val queryApi: InfluxQLQueryApi = influx.influxQLQueryApi
 
         val result = queryApi.query(InfluxQLQuery(
                 "SELECT time, level, message, logSource, loggerName FROM \"$uuid.logs\" " +
@@ -79,7 +67,6 @@ class EndpointLogController(
         }
          */
 
-        //TODO update to influx 2.x changed it[0] to it.values[0]
         return result.results.firstOrNull()?.series?.firstOrNull()?.values?.map {
             LogMessageEntity(
                 time = it.values[0] as String,

--- a/src/main/kotlin/ch/hevs/cloudio/cloud/restapi/endpoint/management/EndpointManagementController.kt
+++ b/src/main/kotlin/ch/hevs/cloudio/cloud/restapi/endpoint/management/EndpointManagementController.kt
@@ -249,7 +249,7 @@ class EndpointManagementController(
         @PathVariable @Parameter(description = "UUID of the endpoint.", required = true) uuid: UUID
     ) = endpointRepository.findById(uuid).orElseThrow {
         CloudioHttpExceptions.NotFound("Endpoint not found.")
-    }.configuration.logLevel
+    }.configuration.logLevel.toString()
 
 
     @GetMapping("/{uuid}/metaData", produces = [MediaType.APPLICATION_JSON_VALUE])
@@ -452,7 +452,7 @@ class EndpointManagementController(
         }
     }
 
-    @PutMapping("/{uuid}/configuration/logLevel", consumes = [MediaType.APPLICATION_JSON_VALUE])
+    @PutMapping("/{uuid}/configuration/logLevel", consumes = [])
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @PreAuthorize("hasPermission(#uuid,T(ch.hevs.cloudio.cloud.security.EndpointPermission).CONFIGURE)")
     @Operation(summary = "Change an endpoint's log level.")

--- a/src/main/kotlin/ch/hevs/cloudio/cloud/security/BrokerPermission.kt
+++ b/src/main/kotlin/ch/hevs/cloudio/cloud/security/BrokerPermission.kt
@@ -1,7 +1,5 @@
 package ch.hevs.cloudio.cloud.security
 
-import java.lang.IllegalArgumentException
-
 enum class BrokerPermission(val value: Int) {
     DENY(0),
     READ(1),

--- a/src/main/kotlin/ch/hevs/cloudio/cloud/security/BrokerSecurityService.kt
+++ b/src/main/kotlin/ch/hevs/cloudio/cloud/security/BrokerSecurityService.kt
@@ -54,7 +54,7 @@ class BrokerSecurityService(private val userDetailsService: CloudioUserDetailsSe
         val body = when (action) {
             "login" -> {
                 val password = message.messageProperties.headers["password"]?.toString()
-                if (password != null) {   // Authentication with password --> User.
+                if (password != null && password != "none") {   // Authentication with password --> User.
                     authenticateUser(id, password)
                 } else {   // Authentication with certificates --> Endpoint.
                     authenticateEndpoint(id)

--- a/src/main/kotlin/ch/hevs/cloudio/cloud/services/DelayedService.kt
+++ b/src/main/kotlin/ch/hevs/cloudio/cloud/services/DelayedService.kt
@@ -78,7 +78,7 @@ class DelayedService(
             //TODO update to influx 2.x
             val point = Point
                     .measurement(modelIdentifier.toInfluxSeriesName())
-                    .time((attribute.timestamp!! * (1000.0) * 1000.0).toLong(), WritePrecision.MS)
+                    .time((attribute.timestamp!! * 1000.0).toLong(), WritePrecision.MS)
                     .addTag("constraint", attribute.constraint.toString())
                     .addTag("type", attribute.type.toString())
 
@@ -120,7 +120,7 @@ class DelayedService(
         val writeApi: WriteApiBlocking = influx.writeApiBlocking
         writeApi.writePoint(influxProperties.database, influxProperties.organization, Point
                 .measurement("$endpointUuid.logs")
-                .time((logMessage.timestamp * (1000.0) * 1000.0).toLong(), WritePrecision.MS)
+                .time((logMessage.timestamp * 1000.0).toLong(), WritePrecision.MS)
                 .addField("level", logMessage.level.ordinal)
                 .addField("message", logMessage.message)
                 .addField("loggerName", logMessage.loggerName)

--- a/src/main/kotlin/ch/hevs/cloudio/cloud/services/DelayedService.kt
+++ b/src/main/kotlin/ch/hevs/cloudio/cloud/services/DelayedService.kt
@@ -75,7 +75,6 @@ class DelayedService(
 
         if (attribute.timestamp != null) {
             // create the influxDB point
-            //TODO update to influx 2.x
             val point = Point
                     .measurement(modelIdentifier.toInfluxSeriesName())
                     .time((attribute.timestamp!! * 1000.0).toLong(), WritePrecision.MS)
@@ -116,7 +115,6 @@ class DelayedService(
     }
 
     fun handleLogMessage(endpointUuid: String, logMessage: LogMessage) {
-        //TODO update to influx 2.x
         val writeApi: WriteApiBlocking = influx.writeApiBlocking
         writeApi.writePoint(influxProperties.database, influxProperties.organization, Point
                 .measurement("$endpointUuid.logs")

--- a/src/main/kotlin/ch/hevs/cloudio/cloud/services/DelayedService.kt
+++ b/src/main/kotlin/ch/hevs/cloudio/cloud/services/DelayedService.kt
@@ -99,7 +99,7 @@ class DelayedService(
                 }
 
                 //if batch enabled, save point in set, either send it
-                writeApi.writePoint(influxProperties.database, "autogen", point)
+                writeApi.writePoint(influxProperties.database, influxProperties.organization, point)
 
             } catch (e: ClassCastException) {
                 log.error("The attribute $modelIdentifier has been updated with wrong data type")
@@ -118,7 +118,7 @@ class DelayedService(
     fun handleLogMessage(endpointUuid: String, logMessage: LogMessage) {
         //TODO update to influx 2.x
         val writeApi: WriteApiBlocking = influx.writeApiBlocking
-        writeApi.writePoint(influxProperties.database, "autogen", Point
+        writeApi.writePoint(influxProperties.database, influxProperties.organization, Point
                 .measurement("$endpointUuid.logs")
                 .time((logMessage.timestamp * (1000.0) * 1000.0).toLong(), WritePrecision.MS)
                 .addField("level", logMessage.level.ordinal)

--- a/src/main/kotlin/ch/hevs/cloudio/cloud/services/DelayedService.kt
+++ b/src/main/kotlin/ch/hevs/cloudio/cloud/services/DelayedService.kt
@@ -5,19 +5,21 @@ import ch.hevs.cloudio.cloud.config.CloudioInfluxProperties
 import ch.hevs.cloudio.cloud.model.*
 import ch.hevs.cloudio.cloud.serialization.SerializationFormat
 import ch.hevs.cloudio.cloud.serialization.detect
+import com.influxdb.client.InfluxDBClient
+import com.influxdb.client.WriteApiBlocking
+import com.influxdb.client.domain.WritePrecision
+import com.influxdb.client.write.Point
 import org.apache.commons.logging.LogFactory
-import org.influxdb.InfluxDB
-import org.influxdb.dto.Point
 import org.springframework.amqp.core.Message
 import org.springframework.amqp.rabbit.core.RabbitTemplate
 import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Service
-import java.util.concurrent.TimeUnit
+
 
 @Service
 @Profile("delayed", "default")
 class DelayedService(
-        private val influx: InfluxDB,
+        private val influx: InfluxDBClient,
         private val serializationFormats: Collection<SerializationFormat>,
         private val influxProperties: CloudioInfluxProperties,
         private val rabbitTemplate: RabbitTemplate
@@ -69,13 +71,16 @@ class DelayedService(
 
     fun handleUpdate(topic: String, attribute: Attribute) {
         val modelIdentifier = ModelIdentifier(topic);
+        val writeApi: WriteApiBlocking = influx.writeApiBlocking
+
         if (attribute.timestamp != null) {
             // create the influxDB point
+            //TODO update to influx 2.x
             val point = Point
                     .measurement(modelIdentifier.toInfluxSeriesName())
-                    .time((attribute.timestamp!! * (1000.0) * 1000.0).toLong(), TimeUnit.MICROSECONDS)
-                    .tag("constraint", attribute.constraint.toString())
-                    .tag("type", attribute.type.toString())
+                    .time((attribute.timestamp!! * (1000.0) * 1000.0).toLong(), WritePrecision.MS)
+                    .addTag("constraint", attribute.constraint.toString())
+                    .addTag("type", attribute.type.toString())
 
             try {
                 // complete the point depending on attribute type
@@ -92,11 +97,9 @@ class DelayedService(
                     else -> {
                     }
                 }
-                //write the actual point in influx
-                val myPoint = point.build()
 
                 //if batch enabled, save point in set, either send it
-                influx.write(influxProperties.database, "autogen", myPoint)
+                writeApi.writePoint(influxProperties.database, "autogen", point)
 
             } catch (e: ClassCastException) {
                 log.error("The attribute $modelIdentifier has been updated with wrong data type")
@@ -113,13 +116,14 @@ class DelayedService(
     }
 
     fun handleLogMessage(endpointUuid: String, logMessage: LogMessage) {
-        influx.write(influxProperties.database, "autogen", Point
+        //TODO update to influx 2.x
+        val writeApi: WriteApiBlocking = influx.writeApiBlocking
+        writeApi.writePoint(influxProperties.database, "autogen", Point
                 .measurement("$endpointUuid.logs")
-                .time((logMessage.timestamp * (1000.0) * 1000.0).toLong(), TimeUnit.MICROSECONDS)
+                .time((logMessage.timestamp * (1000.0) * 1000.0).toLong(), WritePrecision.MS)
                 .addField("level", logMessage.level.ordinal)
                 .addField("message", logMessage.message)
                 .addField("loggerName", logMessage.loggerName)
-                .addField("logSource", logMessage.logSource)
-                .build())
+                .addField("logSource", logMessage.logSource))
     }
 }

--- a/src/main/kotlin/ch/hevs/cloudio/cloud/services/InfluxAttributeService.kt
+++ b/src/main/kotlin/ch/hevs/cloudio/cloud/services/InfluxAttributeService.kt
@@ -4,14 +4,16 @@ import ch.hevs.cloudio.cloud.abstractservices.AbstractAttributeService
 import ch.hevs.cloudio.cloud.config.CloudioInfluxProperties
 import ch.hevs.cloudio.cloud.model.Attribute
 import ch.hevs.cloudio.cloud.model.AttributeType
-import com.influxdb.client.*
-import org.apache.commons.logging.LogFactory
+import com.influxdb.client.InfluxDBClient
+import com.influxdb.client.InfluxQLQueryApi
+import com.influxdb.client.WriteApi
+import com.influxdb.client.WriteOptions
 import com.influxdb.client.domain.InfluxQLQuery
 import com.influxdb.client.domain.WritePrecision
 import com.influxdb.client.write.Point
+import org.apache.commons.logging.LogFactory
 import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Service
-import java.util.concurrent.TimeUnit
 import javax.annotation.PostConstruct
 
 @Service
@@ -24,7 +26,6 @@ class InfluxAttributeService(
     private lateinit var writeApi: WriteApi
     @PostConstruct
     fun initialize() {
-        //TODO update to influx 2.x
         var queryApi: InfluxQLQueryApi = influx.influxQLQueryApi
         // Create database if needed
         if (queryApi.query(InfluxQLQuery("SHOW DATABASES", "")).results.firstOrNull()?.series?.firstOrNull()?.values?.none { it.values.firstOrNull() == influxProperties.database} != false)

--- a/src/main/kotlin/ch/hevs/cloudio/cloud/services/InfluxAttributeService.kt
+++ b/src/main/kotlin/ch/hevs/cloudio/cloud/services/InfluxAttributeService.kt
@@ -39,7 +39,7 @@ class InfluxAttributeService(
             // create the influxDB point
             val point = Point
                     .measurement(attributeId)
-                    .time((attribute.timestamp!! * (1000.0) * 1000.0).toLong(), WritePrecision.MS)
+                    .time((attribute.timestamp!! * 1000.0).toLong(), WritePrecision.MS)
                     .addTag("constraint", attribute.constraint.toString())
                     .addTag("type", attribute.type.toString())
 
@@ -59,7 +59,7 @@ class InfluxAttributeService(
                     }
                 }
                 //if batch enabled, save point in set, either send it
-                writeApi.writePoint(influxProperties.database, "autogen", point)
+                writeApi.writePoint(influxProperties.database, influxProperties.organization, point)
 
             } catch (e: ClassCastException) {
                 log.error("The attribute $attributeId has been updated with wrong data type")

--- a/src/main/kotlin/ch/hevs/cloudio/cloud/services/InfluxLifecycleService.kt
+++ b/src/main/kotlin/ch/hevs/cloudio/cloud/services/InfluxLifecycleService.kt
@@ -4,8 +4,10 @@ import ch.hevs.cloudio.cloud.abstractservices.AbstractLifecycleService
 import ch.hevs.cloudio.cloud.config.CloudioInfluxProperties
 import ch.hevs.cloudio.cloud.model.*
 import org.apache.commons.logging.LogFactory
-import org.influxdb.InfluxDB
-import org.influxdb.dto.Point
+import com.influxdb.client.InfluxDBClient
+import com.influxdb.client.WriteApiBlocking
+import com.influxdb.client.domain.WritePrecision
+import com.influxdb.client.write.Point
 import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Service
 import java.util.*
@@ -14,48 +16,49 @@ import java.util.concurrent.TimeUnit
 @Service
 @Profile("lifecycle-influx", "default")
 class InfluxLifecycleService(
-    private val influx: InfluxDB,
+    private val influx: InfluxDBClient,
     private val influxProperties: CloudioInfluxProperties
 ) : AbstractLifecycleService() {
     private val log = LogFactory.getLog(InfluxLifecycleService::class.java)
 
     override fun endpointIsOnline(endpointUUID: UUID, dataModel: EndpointDataModel) {
-        influx.write(
+        //TODO update to influx 2.x
+        val writeApi: WriteApiBlocking = influx.writeApiBlocking
+        writeApi.writePoint(
             influxProperties.database, "autogen", Point
                 .measurement(endpointUUID.toString())
                 .addField("event", "online")
-                .build()
         )
         dataModel.nodes.writeAttributeValues(endpointUUID.toString())
     }
 
     override fun endpointIsOffline(endpointUUID: UUID) {
-        influx.write(
+        val writeApi: WriteApiBlocking = influx.writeApiBlocking
+        writeApi.writePoint(
             influxProperties.database, "autogen", Point
                 .measurement(endpointUUID.toString())
                 .addField("event", "offline")
-                .build()
         )
     }
 
     override fun nodeAdded(endpointUUID: UUID, nodeName: String, node: Node) {
-        influx.write(
+        val writeApi: WriteApiBlocking = influx.writeApiBlocking
+        writeApi.writePoint(
             influxProperties.database, "autogen", Point
                 .measurement(endpointUUID.toString())
-                .tag("node", nodeName)
+                .addTag("node", nodeName)
                 .addField("event", "added")
-                .build()
         )
         node.writeAttributeValues("$endpointUUID.$nodeName")
     }
 
     override fun nodeRemoved(endpointUUID: UUID, nodeName: String) {
-        influx.write(
+        val writeApi: WriteApiBlocking = influx.writeApiBlocking
+        writeApi.writePoint(
             influxProperties.database, "autogen", Point
                 .measurement(endpointUUID.toString())
-                .tag("node", nodeName)
+                .addTag("node", nodeName)
                 .addField("event", "removed")
-                .build()
         )
     }
 
@@ -78,9 +81,9 @@ class InfluxLifecycleService(
             // create the influxDB point
             val point = Point
                 .measurement(attributeId)
-                .time((timestamp!! * (1000.0) * 1000.0).toLong(), TimeUnit.MICROSECONDS)
-                .tag("constraint", constraint.toString())
-                .tag("type", type.toString())
+                .time((timestamp!! * (1000.0) * 1000.0).toLong(), WritePrecision.MS)
+                .addTag("constraint", constraint.toString())
+                .addTag("type", type.toString())
 
             try {
                 // complete the point depending on attribute type
@@ -97,11 +100,10 @@ class InfluxLifecycleService(
                     else -> {
                     }
                 }
-                //write the actual point in influx
-                val myPoint = point.build()
 
                 //if batch enabled, save point in set, either send it
-                influx.write(influxProperties.database, "autogen", myPoint)
+                val writeApi: WriteApiBlocking = influx.writeApiBlocking
+                writeApi.writePoint(influxProperties.database, "autogen", point)
 
             } catch (e: ClassCastException) {
                 log.error("The attribute $attributeId has been updated with wrong data type")

--- a/src/main/kotlin/ch/hevs/cloudio/cloud/services/InfluxLifecycleService.kt
+++ b/src/main/kotlin/ch/hevs/cloudio/cloud/services/InfluxLifecycleService.kt
@@ -81,7 +81,7 @@ class InfluxLifecycleService(
             // create the influxDB point
             val point = Point
                 .measurement(attributeId)
-                .time((timestamp!! * (1000.0) * 1000.0).toLong(), WritePrecision.MS)
+                .time((timestamp!! * 1000.0).toLong(), WritePrecision.MS)
                 .addTag("constraint", constraint.toString())
                 .addTag("type", type.toString())
 

--- a/src/main/kotlin/ch/hevs/cloudio/cloud/services/InfluxLifecycleService.kt
+++ b/src/main/kotlin/ch/hevs/cloudio/cloud/services/InfluxLifecycleService.kt
@@ -25,7 +25,7 @@ class InfluxLifecycleService(
         //TODO update to influx 2.x
         val writeApi: WriteApiBlocking = influx.writeApiBlocking
         writeApi.writePoint(
-            influxProperties.database, "autogen", Point
+            influxProperties.database, influxProperties.organization, Point
                 .measurement(endpointUUID.toString())
                 .addField("event", "online")
         )
@@ -35,7 +35,7 @@ class InfluxLifecycleService(
     override fun endpointIsOffline(endpointUUID: UUID) {
         val writeApi: WriteApiBlocking = influx.writeApiBlocking
         writeApi.writePoint(
-            influxProperties.database, "autogen", Point
+            influxProperties.database, influxProperties.organization, Point
                 .measurement(endpointUUID.toString())
                 .addField("event", "offline")
         )
@@ -44,7 +44,7 @@ class InfluxLifecycleService(
     override fun nodeAdded(endpointUUID: UUID, nodeName: String, node: Node) {
         val writeApi: WriteApiBlocking = influx.writeApiBlocking
         writeApi.writePoint(
-            influxProperties.database, "autogen", Point
+            influxProperties.database, influxProperties.organization, Point
                 .measurement(endpointUUID.toString())
                 .addTag("node", nodeName)
                 .addField("event", "added")
@@ -55,7 +55,7 @@ class InfluxLifecycleService(
     override fun nodeRemoved(endpointUUID: UUID, nodeName: String) {
         val writeApi: WriteApiBlocking = influx.writeApiBlocking
         writeApi.writePoint(
-            influxProperties.database, "autogen", Point
+            influxProperties.database, influxProperties.organization, Point
                 .measurement(endpointUUID.toString())
                 .addTag("node", nodeName)
                 .addField("event", "removed")
@@ -103,7 +103,7 @@ class InfluxLifecycleService(
 
                 //if batch enabled, save point in set, either send it
                 val writeApi: WriteApiBlocking = influx.writeApiBlocking
-                writeApi.writePoint(influxProperties.database, "autogen", point)
+                writeApi.writePoint(influxProperties.database, influxProperties.organization, point)
 
             } catch (e: ClassCastException) {
                 log.error("The attribute $attributeId has been updated with wrong data type")

--- a/src/main/kotlin/ch/hevs/cloudio/cloud/services/InfluxLifecycleService.kt
+++ b/src/main/kotlin/ch/hevs/cloudio/cloud/services/InfluxLifecycleService.kt
@@ -3,15 +3,14 @@ package ch.hevs.cloudio.cloud.services
 import ch.hevs.cloudio.cloud.abstractservices.AbstractLifecycleService
 import ch.hevs.cloudio.cloud.config.CloudioInfluxProperties
 import ch.hevs.cloudio.cloud.model.*
-import org.apache.commons.logging.LogFactory
 import com.influxdb.client.InfluxDBClient
 import com.influxdb.client.WriteApiBlocking
 import com.influxdb.client.domain.WritePrecision
 import com.influxdb.client.write.Point
+import org.apache.commons.logging.LogFactory
 import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Service
 import java.util.*
-import java.util.concurrent.TimeUnit
 
 @Service
 @Profile("lifecycle-influx", "default")
@@ -22,7 +21,6 @@ class InfluxLifecycleService(
     private val log = LogFactory.getLog(InfluxLifecycleService::class.java)
 
     override fun endpointIsOnline(endpointUUID: UUID, dataModel: EndpointDataModel) {
-        //TODO update to influx 2.x
         val writeApi: WriteApiBlocking = influx.writeApiBlocking
         writeApi.writePoint(
             influxProperties.database, influxProperties.organization, Point

--- a/src/main/kotlin/ch/hevs/cloudio/cloud/services/InfluxLogService.kt
+++ b/src/main/kotlin/ch/hevs/cloudio/cloud/services/InfluxLogService.kt
@@ -21,7 +21,7 @@ class InfluxLogService(
     override fun logMessage(endpointUUID: UUID, message: LogMessage) {
         val writeApi: WriteApiBlocking = influx.writeApiBlocking
         writeApi.writePoint(
-            influxProperties.database, "autogen", Point
+            influxProperties.database, influxProperties.organization, Point
                 .measurement("$endpointUUID.logs")
                 .time((message.timestamp * (1000.0) * 1000.0).toLong(), WritePrecision.MS)
                 .addField("level", message.level.ordinal)

--- a/src/main/kotlin/ch/hevs/cloudio/cloud/services/InfluxLogService.kt
+++ b/src/main/kotlin/ch/hevs/cloudio/cloud/services/InfluxLogService.kt
@@ -23,7 +23,7 @@ class InfluxLogService(
         writeApi.writePoint(
             influxProperties.database, influxProperties.organization, Point
                 .measurement("$endpointUUID.logs")
-                .time((message.timestamp * (1000.0) * 1000.0).toLong(), WritePrecision.MS)
+                .time((message.timestamp * 1000.0).toLong(), WritePrecision.MS)
                 .addField("level", message.level.ordinal)
                 .addField("message", message.message)
                 .addField("loggerName", message.loggerName)

--- a/src/main/kotlin/ch/hevs/cloudio/cloud/services/InfluxLogService.kt
+++ b/src/main/kotlin/ch/hevs/cloudio/cloud/services/InfluxLogService.kt
@@ -3,8 +3,10 @@ package ch.hevs.cloudio.cloud.services
 import ch.hevs.cloudio.cloud.abstractservices.AbstractLogService
 import ch.hevs.cloudio.cloud.config.CloudioInfluxProperties
 import ch.hevs.cloudio.cloud.model.LogMessage
-import org.influxdb.InfluxDB
-import org.influxdb.dto.Point
+import com.influxdb.client.InfluxDBClient
+import com.influxdb.client.WriteApiBlocking
+import com.influxdb.client.domain.WritePrecision
+import com.influxdb.client.write.Point
 import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Service
 import java.util.*
@@ -13,19 +15,19 @@ import java.util.concurrent.TimeUnit
 @Service
 @Profile("logs-influx", "default")
 class InfluxLogService(
-    private val influx: InfluxDB,
+    private val influx: InfluxDBClient,
     private val influxProperties: CloudioInfluxProperties
 ) : AbstractLogService(ignoresLogLevel = true) {
     override fun logMessage(endpointUUID: UUID, message: LogMessage) {
-        influx.write(
+        val writeApi: WriteApiBlocking = influx.writeApiBlocking
+        writeApi.writePoint(
             influxProperties.database, "autogen", Point
                 .measurement("$endpointUUID.logs")
-                .time((message.timestamp * (1000.0) * 1000.0).toLong(), TimeUnit.MICROSECONDS)
+                .time((message.timestamp * (1000.0) * 1000.0).toLong(), WritePrecision.MS)
                 .addField("level", message.level.ordinal)
                 .addField("message", message.message)
                 .addField("loggerName", message.loggerName)
                 .addField("logSource", message.logSource)
-                .build()
         )
     }
 }

--- a/src/main/kotlin/ch/hevs/cloudio/cloud/services/InfluxLogService.kt
+++ b/src/main/kotlin/ch/hevs/cloudio/cloud/services/InfluxLogService.kt
@@ -10,7 +10,6 @@ import com.influxdb.client.write.Point
 import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Service
 import java.util.*
-import java.util.concurrent.TimeUnit
 
 @Service
 @Profile("logs-influx", "default")

--- a/src/main/kotlin/ch/hevs/cloudio/cloud/services/WebSocketAttributeService.kt
+++ b/src/main/kotlin/ch/hevs/cloudio/cloud/services/WebSocketAttributeService.kt
@@ -2,19 +2,8 @@ package ch.hevs.cloudio.cloud.services
 
 import ch.hevs.cloudio.cloud.abstractservices.AbstractAttributeService
 import ch.hevs.cloudio.cloud.model.Attribute
-import org.springframework.context.ApplicationListener
-import org.springframework.messaging.Message
 import org.springframework.messaging.simp.SimpMessagingTemplate
-import org.springframework.messaging.simp.annotation.SubscribeMapping
-import org.springframework.messaging.support.ChannelInterceptor
 import org.springframework.stereotype.Controller
-import org.springframework.messaging.simp.stomp.StompCommand
-
-import org.springframework.messaging.simp.stomp.StompHeaderAccessor
-
-import org.springframework.messaging.MessageChannel
-import org.springframework.messaging.handler.annotation.DestinationVariable
-import org.springframework.messaging.handler.annotation.Payload
 
 
 @Controller

--- a/src/main/kotlin/ch/hevs/cloudio/cloud/services/WebSocketConfig.kt
+++ b/src/main/kotlin/ch/hevs/cloudio/cloud/services/WebSocketConfig.kt
@@ -5,7 +5,10 @@ import ch.hevs.cloudio.cloud.security.WebSocketSecurityService
 import org.springframework.context.annotation.Configuration
 import org.springframework.messaging.simp.config.ChannelRegistration
 import org.springframework.messaging.simp.config.MessageBrokerRegistry
-import org.springframework.web.socket.config.annotation.*
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry
+import org.springframework.web.socket.config.annotation.StompWebSocketEndpointRegistration
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer
 
 
 @Configuration

--- a/src/test/kotlin/ch/hevs/cloudio/cloud/restapi/admin/UserGroupManagementControllerTests.kt
+++ b/src/test/kotlin/ch/hevs/cloudio/cloud/restapi/admin/UserGroupManagementControllerTests.kt
@@ -126,7 +126,7 @@ class UserGroupManagementControllerTests {
     @WithMockUser("Admin", authorities = ["HTTP_ACCESS", "HTTP_ADMIN"])
     fun modifyNonExistentGroup() {
         assertThrows<CloudioHttpExceptions.NotFound> {
-            userGroupManagementController.updateGroupByGroupName("TestGroup2", UserGroupEntity("TestGroup2", mapOf("test" to true)))
+            userGroupManagementController.updateGroupByGroupName("TestGroup2", UserGroupEntity("TestGroup2", mapOf("test" to true), emptyList()))
         }
     }
 
@@ -134,7 +134,7 @@ class UserGroupManagementControllerTests {
     @WithMockUser("Admin", authorities = ["HTTP_ACCESS", "HTTP_ADMIN"])
     fun modifyWhereNamesDoNotMatch() {
         assertThrows<CloudioHttpExceptions.Conflict> {
-            userGroupManagementController.updateGroupByGroupName("TestGroup", UserGroupEntity("TestGroup2", emptyMap()))
+            userGroupManagementController.updateGroupByGroupName("TestGroup", UserGroupEntity("TestGroup2", emptyMap(), emptyList()))
         }
     }
 
@@ -142,7 +142,7 @@ class UserGroupManagementControllerTests {
     @WithMockUser("sepp.blatter", authorities = ["HTTP_ACCESS"])
     fun modifyByNonAdmin() {
         assertThrows<AccessDeniedException> {
-            userGroupManagementController.updateGroupByGroupName("TestGroup", UserGroupEntity("TestGroup", mapOf("test" to true)))
+            userGroupManagementController.updateGroupByGroupName("TestGroup", UserGroupEntity("TestGroup", mapOf("test" to true), emptyList()))
         }
     }
 
@@ -228,7 +228,7 @@ class UserGroupManagementControllerTests {
         }
 
         assertThrows<CloudioHttpExceptions.NotFound> {
-            userGroupManagementController.updateGroupByGroupName(randomCharacters, UserGroupEntity(randomCharacters, emptyMap()))
+            userGroupManagementController.updateGroupByGroupName(randomCharacters, UserGroupEntity(randomCharacters, emptyMap(), emptyList()))
         }
 
         assertThrows<CloudioHttpExceptions.NotFound> {


### PR DESCRIPTION
Updated influx to 2.6.1

- Passed from org.influxdb.influxdb-java to com.influxdb.influxdb-client-java
- Use compatibility api of com.influxdb.influxdb-client-java to keep influxql query
- Use of Token to use influx api ${INFLUX_TOKEN}

Other change:
- Fix log related http api route

Deployement example updated in related PR: https://github.com/cloudio-project/cloudio-deployment-examples/pull/4